### PR TITLE
Create an admin page for deploying a contract and withdrawing funds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ Running Unit tests:
 To Build:
 
 - `npm run build` - This will clean the project, compile the contracts, compile the Typescript, lint, run tests, then bundle everything into the dist folder
+
+To run the admin page:
+
+- `npm run start:admin`

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "@spacedust/typechain": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@spacedust/typechain/-/typechain-0.2.8.tgz",
-      "integrity": "sha512-ORFhNXhNrxR26UbbS84k2+8A7o8ZI47CSk28ofezDU416Pz/ZTdnpZAZJh5um8XeRhn4qKeSkSH/05n6vwnQ9Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@spacedust/typechain/-/typechain-0.3.0.tgz",
+      "integrity": "sha512-rJDP9uX0sD55tYRcqc2OWHqoBV98GBdqj4o+FGDg5ZW24jOT6gjUpzR0WBjeCJdUUoX8X5RqG89AWvjcZU1Gsw==",
       "dev": true,
       "requires": {
         "bignumber.js": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm run clean && npm run gen && tsc && npm run lint && npm run test && npm run build:webpack --progress --profile --colors",
     "dev": "NODE_ENV=development npm start",
     "start": "node_modules/.bin/webpack-dev-server --port 3000 --hot --inline --mode development -d",
+    "start:admin": "node_modules/.bin/webpack-dev-server --port 4000 --hot --inline --mode development -d --config ./webpack.config.admin.js",
     "lint": "npm run lint:typescript && npm run lint:solidity",
     "lint:typescript": "./node_modules/.bin/tslint --force --project tsconfig.json",
     "lint:solidity": "./node_modules/.bin/solium -d ./contracts",
@@ -18,7 +19,7 @@
     "deploy:truffle": "node_modules/.bin/truffle migrate --network ganache --reset"
   },
   "devDependencies": {
-    "@spacedust/typechain": "^0.2.8",
+    "@spacedust/typechain": "^0.3.0",
     "@types/chai": "^4.1.3",
     "@types/d3-scale-chromatic": "^1.2.0",
     "@types/jquery": "^3.3.1",

--- a/src/actionCreators/AccountActions.ts
+++ b/src/actionCreators/AccountActions.ts
@@ -96,7 +96,7 @@ export function loadAndWatchEvents(contractInfo: ContractInfo, currentAddress: s
     dispatch(loadTransactions());
     dispatch(DataActions.clearPlots());
 
-    const newWeb3 = getWeb3(contractInfo);
+    const newWeb3 = getWeb3(contractInfo.web3Provider);
     const contract = await DataActions.initializeContract(contractInfo);
 
     const numberOfPlots = await contract.ownershipLength;

--- a/src/actionCreators/DataActions.ts
+++ b/src/actionCreators/DataActions.ts
@@ -45,7 +45,7 @@ export function clearPlots() {
 }
 
 export function initializeContract(contractInfo: ContractInfo): Promise<EthGrid> {
-  const web3 = getWeb3(contractInfo);
+  const web3 = getWeb3(contractInfo.web3Provider);
   return EthGrid.createAndValidate(web3, contractInfo.contractAddress);
 }
 
@@ -64,7 +64,7 @@ export const determineTxStatus = async (tx: DecodedLogEntry<{}>, web3: Web3): Pr
 
 export function loadBlockInfo(contractInfo: ContractInfo, blockNumber: number) {
   return async (dispatch) => {
-    const web3 = getWeb3(contractInfo);
+    const web3 = getWeb3(contractInfo.web3Provider);
     return new Promise((resolve, reject) => {
       web3.eth.getBlock(blockNumber, (err, blockObj) => {
         if (err) { reject(err); }

--- a/src/actionCreators/Web3Actions.ts
+++ b/src/actionCreators/Web3Actions.ts
@@ -1,16 +1,14 @@
 import * as Web3 from 'web3';
 
-import { ContractInfo } from '../models';
-
 declare global {
   interface Window { web3: Web3; }
 }
 
-export function getWeb3(contractInfo: ContractInfo): Web3 {
+export function getWeb3(web3Provider: string): Web3 {
   if (typeof window !== 'undefined' && typeof window.web3 !== 'undefined') {
     return window.web3;
   } else {
-    return new Web3(new Web3.providers.HttpProvider(contractInfo.web3Provider));
+    return new Web3(new Web3.providers.HttpProvider(web3Provider));
   }
 }
 

--- a/src/admin/Main.tsx
+++ b/src/admin/Main.tsx
@@ -1,0 +1,142 @@
+import { Button, Grid, Typography } from 'material-ui';
+import { withStyles, StyleRulesCallback } from 'material-ui/styles';
+import * as queryString from 'query-string';
+import * as React from 'react';
+import * as Web3 from 'web3';
+
+import { promisify } from '../../gen-src/typechain-runtime';
+import { EthGrid } from '../../gen-src/EthGrid';
+import { getWeb3 } from '../actionCreators/Web3Actions';
+
+const styles: StyleRulesCallback = theme => ({
+  root: {
+    paddingTop: 24,
+    paddingBottom: 16
+  },
+  main: {
+    padding: 20
+  }
+});
+
+interface ContractInfo {
+  balance: string;
+  adminAddress: string;
+  numberOfPlots: string;
+}
+
+export interface MainState {
+  account: string;
+  web3?: Web3;
+  contractAddress: string;
+  isDeploying: boolean;
+  contractInfo?: ContractInfo;
+}
+
+class Main extends React.Component<{}, MainState> {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      account: '',
+      contractAddress: '',
+      isDeploying: false
+    };
+  }
+
+  async deployNewContract() {
+    this.setState({ isDeploying: true });
+    const { account, web3 } = this.state;
+    const tempInstance = new EthGrid(web3, '0x0');
+    const abi = tempInstance.contractAbi as Web3.AbiDefinition[];
+    const bytecode = tempInstance.rawBytecode;
+    const gasEstimate = await promisify(web3!.eth.estimateGas, [{ data: bytecode }]);
+  
+    const rawContract = web3!.eth.contract(abi);
+    const newContractArgs = {
+      data: bytecode,
+      from: account,
+      gas: gasEstimate
+    };
+  
+    const result = await new Promise<{address:string}>((resolve, reject) => {
+      rawContract.new(newContractArgs, (err, data) => {
+        if (err) { return reject(err); }
+        if (data.address) {
+          resolve(data);
+        }
+      });
+    });
+
+    this.setState({ isDeploying: false });
+
+    // Reload the page using this contract address as the query string
+    const newQueryString = queryString.parse(window.location.search);
+    newQueryString.contractAddress = result.address;
+    window.location.search = queryString.stringify(newQueryString);
+  }
+
+  async withdrawContractFunds() {
+    const { web3, contractAddress, account } = this.state;
+    const contractInstance = await EthGrid.createAndValidate(web3, contractAddress);
+    const withdrawTx = contractInstance.withdrawTx(account);
+    const gasEstimate = await withdrawTx.estimateGas({ from: account });
+    const transactionResult = await withdrawTx.send({ from: account, gas: gasEstimate.times(2) });
+    alert(`Withdraw Succeeded! ${transactionResult}`);
+  }
+  
+  async componentDidMount() {
+    const web3Location = '';
+    const web3 = getWeb3(web3Location);
+    const accounts: string[] = await promisify(web3.eth.getAccounts, []);
+    const account = accounts[0];
+    const contractAddress = queryString.parse(window.location.search).contractAddress;
+    let contractInfo: ContractInfo | undefined = undefined;
+    if (contractAddress) {
+      // Grab some info about the contract
+      const contractInstance = await EthGrid.createAndValidate(web3, contractAddress);
+      const adminAddress = await contractInstance.owner;
+      const balance: string = (await promisify(web3.eth.getBalance, [contractAddress])).toString();
+      const numberOfPlots = (await contractInstance.ownershipLength).toString();
+      contractInfo = {
+        adminAddress,
+        balance,
+        numberOfPlots
+      };
+    }
+
+    this.setState({ account, web3, contractAddress, contractInfo });
+  }
+
+  render() {
+    let instanceInfo: null | JSX.Element[] = null;
+    if (this.state.contractInfo) {
+      const isOwner = this.state.contractInfo.adminAddress === this.state.account;
+      instanceInfo = [
+        (<Typography variant="headline">Contract deployed at: {this.state.contractAddress}</Typography>),
+        (<Typography variant="headline">Contract Balance: {this.state.contractInfo.balance}</Typography>),
+        (<Typography variant="headline">Number of Plots: {this.state.contractInfo.numberOfPlots}</Typography>),
+        (<Typography gutterBottom={true} variant="headline">Owner Address: {this.state.contractInfo.adminAddress}</Typography>),
+        (<Button onClick={this.withdrawContractFunds.bind(this)} color="primary" variant="raised" disabled={!isOwner}>
+          {isOwner ? 'Withdraw Contract Funds' : 'Cannot withdraw, not the owner'}
+        </Button>)
+      ];
+    }
+
+
+    return (<Grid container justify="center" spacing={16}>
+      <Grid item xs={8}>
+        <Typography variant="headline"> Hello Admin: {this.state.account} </Typography>
+      </Grid>
+      <Grid item xs={8}>
+        <Button onClick={this.deployNewContract.bind(this)} color="primary" variant="raised" disabled={this.state.isDeploying}>
+          {this.state.isDeploying ? 'Deploying Contract...' : 'Deploy New Contract Instance'}
+        </Button>
+      </Grid>
+      <Grid item xs={8}>
+        {instanceInfo}
+      </Grid>
+    </Grid >);
+  }
+}
+
+export default withStyles(styles)(Main);

--- a/src/admin/index.tsx
+++ b/src/admin/index.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import Main from './Main';
+
+
+
+ReactDOM.render(
+  (<Main />),document.body.appendChild(document.createElement('div')));

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -67,7 +67,7 @@ class App extends React.Component<AppProps> {
   }
 
   checkMetamaskStatus(contractInfo: ContractInfo) {
-    const web3 = getWeb3(contractInfo);
+    const web3 = getWeb3(contractInfo.web3Provider);
 
     if (!web3 || !web3.isConnected()) {
       this.updateMetamaskState(Enums.METAMASK_STATE.UNINSTALLED);

--- a/webpack.config.admin.js
+++ b/webpack.config.admin.js
@@ -1,0 +1,33 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const path = require('path');
+
+module.exports = {
+  entry: './src/admin/index.tsx',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: {
+          loader: 'ts-loader',
+          options: {
+            transpileOnly: true //HMR doesn't work without this
+          }
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json']
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: 'Eth Plot Admin Page'
+    }),
+    new ForkTsCheckerWebpackPlugin()
+  ],
+  devServer: {
+    contentBase: path.resolve('../public')
+  },
+  performance: { hints: false }
+};


### PR DESCRIPTION
It's just a simple page which lets you deploy a new contract, see some details about the deployed one, or withdraw the funds from the contract (if you're the admin)

I introduced a new webpack script for a dev server to completely isolate this from what's deployed to ethplot.com, but allow to use any of the code from the main project

<img width="1515" alt="screen shot 2018-05-16 at 10 54 15 am" src="https://user-images.githubusercontent.com/4925051/40134873-86de91c8-58f8-11e8-8367-e5722a9e4409.png">
